### PR TITLE
Windows - no strndup

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -70,7 +70,7 @@ static size_t xml_quotedspn( const char *s, char q )
 	return 0;
 }
 
-#ifndef strndup
+#ifdef WIN32
 /**
  * Copies n bytes of given string
  *

--- a/xml.c
+++ b/xml.c
@@ -81,7 +81,7 @@ static char *strndup( const char *s, size_t n )
 {
 	char *r;
 
-	if( !(r = calloc( n+1, sizeof( char )) ) ||
+	if( !(r = calloc( n+1, sizeof( char ) )) ||
 		!memcpy( r, s, n ) )
 		return NULL;
 

--- a/xml.c
+++ b/xml.c
@@ -70,6 +70,25 @@ static size_t xml_quotedspn( const char *s, char q )
 	return 0;
 }
 
+#ifndef strndup
+/**
+ * Copies n bytes of given string
+ *
+ * @param s - string to copy
+ * @param n - number of bytes
+ */
+static char *strndup( const char *s, size_t n )
+{
+	char *r;
+
+	if( !(r = calloc( n+1, sizeof( char )) ) ||
+		!memcpy( r, s, n ) )
+		return NULL;
+
+	return r;
+}
+#endif
+
 /**
  * Append string
  *


### PR DESCRIPTION
Sadly Windows doesn't know strndup and can't compile it.
Maybe defining our own strndup routine saves the day for Windows users.
